### PR TITLE
Only download checkstyle/ktlint if not exists (#141)

### DIFF
--- a/packages/nx-boot-maven/src/utils/command.ts
+++ b/packages/nx-boot-maven/src/utils/command.ts
@@ -92,8 +92,9 @@ export async function getKtlintAbsolutePath() {
   }
 
   const ktlintAbsolutePath = path.join(outputDirectory, 'ktlint');
-
-  await downloadFile(downloadUrl, ktlintAbsolutePath);
+  if(!fs.existsSync(ktlintAbsolutePath)) {
+    await downloadFile(downloadUrl, ktlintAbsolutePath);
+  }
   return ktlintAbsolutePath;
 }
 
@@ -131,7 +132,9 @@ export async function getCheckstyleJarAbsolutePath() {
     checkstyleJarName
   );
 
-  await downloadFile(downloadUrl, checkstyleJarAbsolutePath);
+  if(!fs.existsSync(checkstyleJarAbsolutePath)) {
+    await downloadFile(downloadUrl, checkstyleJarAbsolutePath);
+  }
   return checkstyleJarAbsolutePath;
 }
 


### PR DESCRIPTION
Re issue #141:

At the moment checkstyle/ktlint is downloaded even if the file already exists. This caused us to get some weird errors when we ran multiple checks in parallel, where checkstyle would throw due to a corrupted jar file. After setting parallel = 1, they work every time. 

What happens:
We start 9 lint-jobs (5 eslint, 4 checkstyle). First checkstyle always works out. What happens then is that 2 eslint projects are done mostly at the same time, which causes checkstyle project B to start downloading checkstyle.jar, and while it is downloading checkstyle.jar, checkstyle project C also starts downloading checkstyle.jar to the same location. When project B starts linting, project C is still downloading the jar file, causing the job for project B to error out.

The below change seems to fix this