### PR TITLE
feat(nx-maven): expose the utility to get maven workspace metadata

### DIFF
--- a/packages/nx-maven/src/index.ts
+++ b/packages/nx-maven/src/index.ts
@@ -16,3 +16,9 @@ export {
   applicationGenerator,
   runTaskExecutor,
 };
+
+export {
+  getWorkspaceData as getMavenWorkspaceData,
+  WorkspaceDataType,
+  MavenProjectType,
+} from './graph/graph-utils';


### PR DESCRIPTION
Hey,

I’m already using the library, but I’d like to access Maven data from other plugins.
Rather than rewriting the code, I’d prefer to reuse the existing cached workspace data.