### PR TITLE
chore(nx-maven): improve workspace data caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@nx/devkit": "21.5.3",
         "@swc/helpers": "0.5.17",
         "create-nx-workspace": "21.5.3",
-        "flat-cache": "^6.1.14",
         "tslib": "^2.8.1"
       },
       "devDependencies": {
@@ -30,7 +29,6 @@
         "@swc/cli": "0.7.8",
         "@swc/core": "1.13.5",
         "@swc/wasm": "~1.13.5",
-        "@types/flat-cache": "^2.0.2",
         "@types/jest": "30.0.0",
         "@types/kill-port": "^2.0.3",
         "@types/node": "24.5.2",
@@ -2035,34 +2033,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@cacheable/memoize": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.1.tgz",
-      "integrity": "sha512-WBLH37SynkCa39S6IrTSMQF3Wdv4/51WxuU5TuCNEqZcLgLGHme8NUxRTcDIO8ZZFXlslWbh9BD3DllixgPg6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@cacheable/utils": "^2.0.1"
-      }
-    },
-    "node_modules/@cacheable/memory": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.1.tgz",
-      "integrity": "sha512-Ufc7iQnRKFC8gjZVGOTOsMwM/vZtmsw3LafvctVXPm835ElgK3DpMe1U5i9sd6OieSkyJhXbAT2Q2FosXBBbAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@cacheable/memoize": "^2.0.1",
-        "@cacheable/utils": "^2.0.1",
-        "@keyv/bigmap": "^1.0.0",
-        "hookified": "^1.12.0",
-        "keyv": "^5.5.1"
-      }
-    },
-    "node_modules/@cacheable/utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.0.1.tgz",
-      "integrity": "sha512-sxHjO6wKn4/0wHCFYbh6tljj+ciP9BKgyBi09NLsor3sN+nu/Rt3FwLw6bYp7bp8usHpmcwUozrB/u4RuSw/eg==",
-      "license": "MIT"
-    },
     "node_modules/@commitlint/cli": {
       "version": "19.8.1",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
@@ -3614,24 +3584,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@keyv/bigmap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.0.0.tgz",
-      "integrity": "sha512-N2UsRSXlWwbvYKdFVS7sKqj6oXGegELh+zr9VripWDc8grsq8KBNp8JHI+9AQuUEFiM1S7+tm6lLp/lmbBCqCw==",
-      "license": "MIT",
-      "dependencies": {
-        "hookified": "^1.10.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@keyv/serialize": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
-      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT"
     },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.1",
@@ -5254,13 +5206,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/flat-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/flat-cache/-/flat-cache-2.0.2.tgz",
-      "integrity": "sha512-uZRK+n0d9JBzcEqjRJGD9SiPtDKUn4E5w4n6iFHqAdgylJFc2Eh2KK9UimvH/saz6dwGC36Jt1DzyKBvHiEIgA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -5472,153 +5417,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
-      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.44.1",
-        "@typescript-eslint/types": "^8.44.1",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
-      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
-      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
-      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
-      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.44.1",
-        "@typescript-eslint/tsconfig-utils": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
-      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
@@ -7588,19 +7386,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cacheable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.0.1.tgz",
-      "integrity": "sha512-MSKxcybpxB5kcWKpj+1tPBm2os4qKKGxDovsZmLhZmWIDYp8EgtC45C5zk1fLe1IC9PpI4ZE4eyryQH0N10PKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@cacheable/memoize": "^2.0.1",
-        "@cacheable/memory": "^2.0.1",
-        "@cacheable/utils": "^2.0.1",
-        "hookified": "^1.12.0",
-        "keyv": "^5.5.1"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -9825,21 +9610,11 @@
         "flat": "cli.js"
       }
     },
-    "node_modules/flat-cache": {
-      "version": "6.1.14",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.14.tgz",
-      "integrity": "sha512-ExZSCSV9e7v/Zt7RzCbX57lY2dnPdxzU/h3UE6WJ6NtEMfwBd8jmi1n4otDEUfz+T/R+zxrFDpICFdjhD3H/zw==",
-      "license": "MIT",
-      "dependencies": {
-        "cacheable": "^2.0.1",
-        "flatted": "^3.3.3",
-        "hookified": "^1.12.0"
-      }
-    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -10351,12 +10126,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/hookified": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.0.tgz",
-      "integrity": "sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ==",
-      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -12336,15 +12105,6 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/keyv": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.1.tgz",
-      "integrity": "sha512-eF3cHZ40bVsjdlRi/RvKAuB0+B61Q1xWvohnrJrnaQslM3h1n79IV+mc9EGag4nrA9ZOlNyr3TUzW5c8uy8vNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/kill-port": {
@@ -15978,31 +15738,6 @@
         "@typescript-eslint/parser": "8.44.1",
         "@typescript-eslint/typescript-estree": "8.44.1",
         "@typescript-eslint/utils": "8.44.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz",
-      "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.44.0",
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/typescript-estree": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0",
-        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@nx/devkit": "21.5.3",
     "@swc/helpers": "0.5.17",
     "create-nx-workspace": "21.5.3",
-    "flat-cache": "^6.1.14",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
@@ -38,7 +37,6 @@
     "@swc/cli": "0.7.8",
     "@swc/core": "1.13.5",
     "@swc/wasm": "~1.13.5",
-    "@types/flat-cache": "^2.0.2",
     "@types/jest": "30.0.0",
     "@types/kill-port": "^2.0.3",
     "@types/node": "24.5.2",

--- a/packages/nx-maven/src/utils/index.ts
+++ b/packages/nx-maven/src/utils/index.ts
@@ -71,9 +71,9 @@ function isWrapperExistsFunction(mavenRootDirectory: string) {
   return fs.existsSync(mvnwPath);
 }
 
-export function getMavenRootDirectory(): string {
-  const plugin = getPlugin();
-
+export function getMavenRootDirectory(
+  plugin: PluginConfiguration | undefined = getPlugin(),
+): string {
   if (typeof plugin === 'string') {
     return '';
   }
@@ -431,6 +431,31 @@ export function getSkipAggregatorProjectLinkingOption(
       typeof graphOptions.skipAggregatorProjectLinking === 'boolean'
     ) {
       return graphOptions.skipAggregatorProjectLinking;
+    }
+  }
+
+  return false;
+}
+
+export function getSkipProjectWithoutProjectJsonOption(
+  plugin: PluginConfiguration | undefined,
+): boolean {
+  if (typeof plugin === 'string') {
+    return false;
+  }
+
+  const options = plugin?.options;
+
+  if (typeof options === 'object' && options && 'graphOptions' in options) {
+    const graphOptions = options?.graphOptions;
+
+    if (
+      typeof graphOptions === 'object' &&
+      graphOptions &&
+      'skipProjectWithoutProjectJson' in graphOptions &&
+      typeof graphOptions.skipProjectWithoutProjectJson === 'boolean'
+    ) {
+      return graphOptions.skipProjectWithoutProjectJson;
     }
   }
 


### PR DESCRIPTION
As mentioned in my previous PR ([https://github.com/gridatek/jnxplus/pull/1889](https://github.com/gridatek/jnxplus/pull/1889)), I’d like to re-use parts of the library by specializing them for specific use cases.

## Current

When creating nodes, we call the `getWorkspaceData` utility, which generates a workspace dataset by reading and parsing all `pom.xml` files.

Later, when creating dependencies, this dataset is reused to avoid parsing all `pom.xml` files again.

However, once the dependencies are created, the cached data is discarded. As a result, a new dataset must be re-generated each time `getWorkspaceData` is called.

## Expected

Introduce a cache that persists until any `pom.xml` file is modified.

## Modifications

### `getWorkspaceData`

* Introduced a `getNormalizedOptions` function to centralize option handling.
* Added caching:

  * Workspace data is cached based on plugin options **and** the full content of all `pom.xml` files. Cache is invalidated if any of these change.
  * Cache is integrated with Nx workspace data and cleared on `nx reset`.
  * If `NX_CACHE_PROJECT_GRAPH=false`, caching is disabled.
  * Uses the Nx cache utility (Rust-based) to scan and hash `pom.xml` contents.
  * Removed the `flat-cache` dependency.

### `getNormalizedOptions`

* Reads plugin options and applies defaults each time.
* Normalization results are cached to avoid repeated option reads.
* (Optional improvement: we could restrict normalization to only the provided parameters, though I understand the current approach is also useful for generators/executors.)

### `createDependencies`

* Instead of iterating over every file, we directly iterate over the list of Maven projects.
* Calls `getWorkspaceData` directly (which now returns cached or freshly generated data) instead of `getCachedWorkspaceData`.