### PR TITLE
ci: use Node 26 for single-version workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: ['24']
+        node_version: ['26']
         java: ['17']
       fail-fast: true
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: ['24']
+        node_version: ['26']
         java: ['17']
     runs-on: ${{ matrix.os }}
     if: ${{ github.actor == 'dependabot[bot]' || (github.event.pull_request.user.login == 'dependabot[bot]' && github.actor == '@kgridou') }}

--- a/.github/workflows/e2e-plugin.yml
+++ b/.github/workflows/e2e-plugin.yml
@@ -46,7 +46,7 @@ jobs:
     name: Running ${{ github.event.inputs.t_option }} tests from ${{ github.head_ref || github.ref_name }} branch on ${{ github.event.inputs.os }}
     strategy:
       matrix:
-        node_version: ['24']
+        node_version: ['26']
         java: ['17']
       fail-fast: true
     runs-on: ${{ github.event.inputs.os }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         #        os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        node_version: ['24', '25']
+        node_version: ['24', '26']
         java: ['17']
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: ['24']
+        node_version: ['26']
         java: ['17']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/nx-release.yml
+++ b/.github/workflows/nx-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js v20
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 26
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/.github/workflows/publish-gradle-plugin.yml
+++ b/.github/workflows/publish-gradle-plugin.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js v20
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 26
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/.github/workflows/regenerate-package-lock.yml
+++ b/.github/workflows/regenerate-package-lock.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: ['24']
+        node_version: ['26']
         java: ['17']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/smoke-affected.yml
+++ b/.github/workflows/smoke-affected.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        node_version: ['24']
+        node_version: ['26']
         java: ['21']
     runs-on: ${{matrix.os}}
     env:

--- a/.github/workflows/smoke-next.yml
+++ b/.github/workflows/smoke-next.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        node_version: ['24']
+        node_version: ['26']
         java: ['17']
     runs-on: ${{matrix.os}}
     env:

--- a/.github/workflows/smoke-plugin.yml
+++ b/.github/workflows/smoke-plugin.yml
@@ -51,7 +51,7 @@ jobs:
     name: Running ${{ github.event.inputs.t_option }} smoke tests with nx ${{ github.event.inputs.nx_tag_option }} version and jnxplus ${{ github.event.inputs.tag_option }} version from ${{ github.head_ref || github.ref_name }} branch
     strategy:
       matrix:
-        node_version: ['24']
+        node_version: ['26']
         java: ['17']
       fail-fast: true
     runs-on: ${{ github.event.inputs.os }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node_version: ['24', '25']
+        node_version: ['24', '26']
         java: ['17']
     runs-on: ${{matrix.os}}
     env:


### PR DESCRIPTION
Single-version workflows now run on Node 26; e2e and smoke matrices test the latest LTS (24) plus the current line (26).