### PR TITLE
ci: cache Gradle and Maven to harden greclipse provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,21 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      # Cache the Gradle home so Spotless' greclipse formatter (provisioned from
+      # the flaky download.eclipse.org P2 site) is downloaded once and reused,
+      # and cache the Maven local repo so generated Maven e2e workspaces don't
+      # re-download every dependency (and are less exposed to transient outages).
+      - name: Cache Gradle & Maven
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+
       - name: Install dependencies
         run: npm i
 

--- a/.github/workflows/e2e-plugin.yml
+++ b/.github/workflows/e2e-plugin.yml
@@ -66,6 +66,21 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      # Cache the Gradle home so Spotless' greclipse formatter (provisioned from
+      # the flaky download.eclipse.org P2 site) is downloaded once and reused,
+      # and cache the Maven local repo so generated Maven e2e workspaces don't
+      # re-download every dependency (and are less exposed to transient outages).
+      - name: Cache Gradle & Maven
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+
       - name: Install dependencies
         run: npm i
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,21 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      # Cache the Gradle home so Spotless' greclipse formatter (provisioned from
+      # the flaky download.eclipse.org P2 site) is downloaded once and reused,
+      # and cache the Maven local repo so generated Maven e2e workspaces don't
+      # re-download every dependency (and are less exposed to transient outages).
+      - name: Cache Gradle & Maven
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+
       - name: Install dependencies
         run: npm i
 

--- a/.github/workflows/publish-gradle-plugin.yml
+++ b/.github/workflows/publish-gradle-plugin.yml
@@ -20,6 +20,19 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      # Cache the Gradle home so Spotless' greclipse formatter (provisioned from
+      # the flaky download.eclipse.org P2 site) is downloaded once and reused,
+      # so a publish isn't blocked by a transient download.eclipse.org outage.
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/smoke-affected.yml
+++ b/.github/workflows/smoke-affected.yml
@@ -60,6 +60,21 @@ jobs:
         with:
           maven-version: 3.9.9
 
+      # Cache the Gradle home so Spotless' greclipse formatter (provisioned from
+      # the flaky download.eclipse.org P2 site) is downloaded once and reused,
+      # and cache the Maven local repo so generated Maven smoke workspaces don't
+      # re-download every dependency (and are less exposed to transient outages).
+      - name: Cache Gradle & Maven
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+
       - name: Install dependencies
         run: npm i
 

--- a/.github/workflows/smoke-next.yml
+++ b/.github/workflows/smoke-next.yml
@@ -60,6 +60,21 @@ jobs:
         with:
           maven-version: 3.9.9
 
+      # Cache the Gradle home so Spotless' greclipse formatter (provisioned from
+      # the flaky download.eclipse.org P2 site) is downloaded once and reused,
+      # and cache the Maven local repo so generated Maven smoke workspaces don't
+      # re-download every dependency (and are less exposed to transient outages).
+      - name: Cache Gradle & Maven
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+
       - name: Install dependencies
         run: npm i
 

--- a/.github/workflows/smoke-plugin.yml
+++ b/.github/workflows/smoke-plugin.yml
@@ -74,6 +74,21 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      # Cache the Gradle home so Spotless' greclipse formatter (provisioned from
+      # the flaky download.eclipse.org P2 site) is downloaded once and reused,
+      # and cache the Maven local repo so generated Maven smoke workspaces don't
+      # re-download every dependency (and are less exposed to transient outages).
+      - name: Cache Gradle & Maven
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+
       - name: Install dependencies
         run: npm i
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -56,6 +56,21 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      # Cache the Gradle home so Spotless' greclipse formatter (provisioned from
+      # the flaky download.eclipse.org P2 site) is downloaded once and reused,
+      # and cache the Maven local repo so generated Maven smoke workspaces don't
+      # re-download every dependency (and are less exposed to transient outages).
+      - name: Cache Gradle & Maven
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+
       - name: Install dependencies
         run: npm i
 


### PR DESCRIPTION
The e2e/CI/smoke workflows build the gradle-plugin, whose Spotless `greclipse()` step provisions the Groovy-Eclipse formatter from download.eclipse.org's P2 site. That server intermittently returns HTTP 500, failing the whole build (e.g. run 28731401431).

Cache ~/.gradle (and ~/.m2 for the generated Maven workspaces) so the formatter and dependencies are fetched once and reused across runs instead of hitting the flaky server every time. publish-gradle-plugin gets a Gradle-only cache; gradle-plugin-test already caches via gradle/actions/setup-gradle.